### PR TITLE
Change/no ref/pricing page

### DIFF
--- a/_includes/css/main.css
+++ b/_includes/css/main.css
@@ -504,3 +504,83 @@ a.anchor{
   margin-top: 1em;
   margin-bottom: 1em;
 }
+
+/* Pricing page */
+.pricing-table {
+	display: flex;
+	justify-content: space-around;
+	background-color: transparent;
+	width: 90%;
+	margin: auto;
+	gap: 2em; 
+}
+
+.plan {
+	border: 1px solid #ccc;
+	padding: 1em;
+	flex: 1;
+	box-sizing: border-box;
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	justify-content: space-between;
+	border-radius: 25px;
+}
+
+.plan.enterprise {
+	border: 2px solid #2b0548;
+}
+
+.plan-title {
+	color: #2b0548;
+}
+
+.price {
+	font-size: 2em;
+	font-weight: bold;
+	color: #333;
+	margin-bottom: 0.5em;
+	width: 100%; 
+}
+
+.plan-description {
+	color: #666;
+	margin-bottom: 1em;
+	width: 100%;
+}
+
+.features {
+	list-style-type: none;
+	padding: 0;
+	text-align: left;
+	width: 100%; 
+	margin-bottom: 1em;
+}
+
+.features li::before {
+	content: '✔️';
+	margin-right: 0.5em;
+}
+
+.btn {
+	display: inline-block;
+	font-size: 1em;
+	padding: 0.5em 1em;
+	background-color: #2b0548;
+	color: white;
+	text-decoration: none;
+	margin-top: auto;
+	width: 100%;
+	text-align: center;
+	border-radius: 25px; 
+}
+
+.btn:hover {
+	color: white;
+}
+
+.btn.community {
+	background-color: white;
+	color: #2b0548;
+	border: 2px solid #2b0548;
+}

--- a/_includes/css/main.css
+++ b/_includes/css/main.css
@@ -562,7 +562,7 @@ a.anchor{
 	margin-right: 0.5em;
 }
 
-.btn {
+.btn-pricing {
 	display: inline-block;
 	font-size: 1em;
 	padding: 0.5em 1em;
@@ -575,11 +575,11 @@ a.anchor{
 	border-radius: 25px; 
 }
 
-.btn:hover {
+.btn-pricing:hover {
 	color: white;
 }
 
-.btn.community {
+.btn-pricing.community {
 	background-color: white;
 	color: #2b0548;
 	border: 2px solid #2b0548;

--- a/_includes/pricing_table.html
+++ b/_includes/pricing_table.html
@@ -24,7 +24,7 @@
             <li>Unlimited Usage</li>
             <li>Free Development Usage</li>
             <li>Storage-Based Pricing</li>
-            <li>Annual Solution Review</li>
+            <li>Continuous Support and Guidance</li>
         </ul>
         <a href="/contact" class="btn-pricing enterprise">Contact Sales</a>
     </div>

--- a/_includes/pricing_table.html
+++ b/_includes/pricing_table.html
@@ -11,7 +11,7 @@
             <li>Open Source & Free</li>
             <li>No Limitations on Features</li>
         </ul>
-        <a class="btn community" href="https://docs.reduct.store/">Get Started</a>
+        <a class="btn-pricing community" href="https://docs.reduct.store/">Get Started</a>
     </div>
     <div class="plan enterprise">
         <h2 class="plan-title">Enterprise Edition</h2>
@@ -26,6 +26,6 @@
             <li>Storage-Based Pricing</li>
             <li>Annual Solution Review</li>
         </ul>
-        <a href="/contact" class="btn">Contact Sales</a>
+        <a href="/contact" class="btn-pricing enterprise">Contact Sales</a>
     </div>
 </div>

--- a/_includes/pricing_table.html
+++ b/_includes/pricing_table.html
@@ -22,7 +22,7 @@
 
         <ul class="features">
             <li>Unlimited Usage</li>
-            <li>Complimentary Development Usage</li>
+            <li>Free Development Usage</li>
             <li>Storage-Based Pricing</li>
             <li>Annual Solution Review</li>
         </ul>

--- a/_includes/pricing_table.html
+++ b/_includes/pricing_table.html
@@ -1,8 +1,31 @@
-<script async src="https://js.stripe.com/v3/pricing-table.js"></script>
-<stripe-pricing-table pricing-table-id="prctbl_1MycocBKYlfcheCvAR6SL7cR"
-                      publishable-key="pk_live_51MySzVBKYlfcheCvkJcURFxkzjlK0ff23IYJ4K8SsUGiZ2hZORKmk4feLpzUw5gpvUpk0XLR5niZESAecY9EsW6I00AptUDPnP">
-</stripe-pricing-table>
-<div class="text-center">
-    By subscribing to any plan, you agree to our <a href="/terms_and_conditions">Subscription Agreement</a> and <a
-        href="/privacy_policy">Privacy Policy</a>.
+<div class="pricing-table">
+    <div class="plan">
+        <h2 class="plan-title">Community</h2>
+
+        <h3 class="price">Totally Free of Charge</h3>
+
+        <p class="plan-description">Ideal for entities with finances below $2M</p>
+
+        <ul class="features">
+            <li>Unbounded Usage</li>
+            <li>Open Source & Free</li>
+            <li>No Limitations on Features</li>
+        </ul>
+        <a class="btn community" href="https://docs.reduct.store/">Get Started</a>
+    </div>
+    <div class="plan enterprise">
+        <h2 class="plan-title">Enterprise Edition</h2>
+
+        <h3 class="price">Custom Pricing</h3>
+
+        <p class="plan-description">For larger firms needing custom solutions</p>
+
+        <ul class="features">
+            <li>Unlimited Usage</li>
+            <li>Complimentary Development Usage</li>
+            <li>Storage-Based Pricing</li>
+            <li>Annual Solution Review</li>
+        </ul>
+        <a href="/contact" class="btn">Contact Sales</a>
+    </div>
 </div>

--- a/pricing.html
+++ b/pricing.html
@@ -1,23 +1,24 @@
 ---
 layout: page
-title: ReductStore Pricing
+title: Empowering Growth with our Business Source License
 description: Price page for ReductStore with pricing plans and pricing details
 permalink: /pricing
 ---
 
+<p>
+    Experience the power of transparency and freedom with our Business Source License. Explore, customize, and
+    share our source code - it's
+    your playground for innovation, whether for commercial or non-commercial initiatives.
+</p>
 
-<p><b>Open Source License:</b> Our project is available under the Mozilla Public License v2 (MPLv2),
-    which allows for free use, modification, and distribution of the source code for both commercial and
-    non-commercial purposes.
-    However, users must make any modifications to the source code available to the public if they distribute the
-    database.
-</p>
-<p><b>Commercial Usage:</b> For companies or individuals who are using the project for commercial
-    purposes and need support from our team, we also offer a subscription model. This  does not provide any additional rights to
-    use the project beyond what is granted under the MPLv2, but it does include support and expertise from our team.
-</p>
+<br>
 
 {% include pricing_table.html %}
 
+<br>
 
-
+<p>
+    No boundaries, no vendor chains, no hidden charges - we've eliminated them all. Our software levels the playing
+    field for startups and provides scalability for enterprises. As you drive success and realize
+    substantial benefits, we encourage a reasonable contribution via a commercial license.
+</p>


### PR DESCRIPTION
This PR brings a significant revamp to our pricing table with both Community and Enterprise offerings.

See the updated design below:

<img width="1588" alt="pricing-page" src="https://github.com/reductstore/homepage/assets/26444489/d49c7d3d-af88-4284-8421-3ed1f066aec9">

