### PR TITLE
Responsive Update for Pricing Table

### DIFF
--- a/_includes/css/main.css
+++ b/_includes/css/main.css
@@ -631,3 +631,20 @@ a.anchor{
 	color: #2b0548;
 	border: 2px solid #2b0548;
 }
+
+/* Mobile styles */
+@media (max-width: 768px) {
+  
+  .pricing-table {
+    flex-direction: column;
+    gap: 1em;
+  }
+
+  .plan {
+    width: 100%; 
+    margin-bottom: 1em; 
+  }
+
+  .btn-pricing {
+    padding: 1em 1.5em; 
+}


### PR DESCRIPTION
This PR introduces mobile-responsive styling for the pricing table.
The pricing table changes when the width is 768px or lower (iPad Mini or smaller).

<img width="862" alt="Screenshot 2023-08-11 at 17 57 58" src="https://github.com/reductstore/homepage/assets/26444489/da835c84-afd4-447c-a862-af78b1c081aa">
